### PR TITLE
Split build/report for PRs to allow test results for PRs from forks

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Build PR
 
 on: pull_request
 
@@ -16,8 +16,7 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew check
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v2
+      - uses: actions/upload-artifact@v2
         with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
-          github_token: ${{ secrets.GITHUB_TOKEN }}        
+          name: test-results
+          path: "**/build/test-results/test/TEST-*.xml"

--- a/.github/workflows/pr-publish-test-results.yaml
+++ b/.github/workflows/pr-publish-test-results.yaml
@@ -1,0 +1,46 @@
+name: Publish PR Test Results
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: [ "Build PR" ]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "test-results"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip test-results.zip
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v2
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_on_failure: true
+          require_tests: true
+          commit: ${{github.event.workflow_run.head_sha}}

--- a/.github/workflows/publishrelease.yml
+++ b/.github/workflows/publishrelease.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          require_tests: true
+          fail_on_failure: true
       - name: "Build Changelog"
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v1.7.1


### PR DESCRIPTION
in #21 we see that test reports cannot be reported from CI on PRs from forks. This PR should solve this.